### PR TITLE
Added information_popup_type_filter that allow to

### DIFF
--- a/data/default_config.cfg
+++ b/data/default_config.cfg
@@ -198,6 +198,11 @@ use_bookmarks_method =
 # Possible values; error, roster, warning, info, help
 #information_buffer_popup_on = error roster warning help info
 
+# A list of message types that should be filtered out from the
+# information buffer.
+# Possible values; error, roster, warning, info, help
+#information_buffer_type_filter =
+
 # The time the message will be visible. If the message takes more than
 # one line, the popup will stay visible two second per additional lines
 #popup_time = 4

--- a/data/default_config.cfg
+++ b/data/default_config.cfg
@@ -198,7 +198,7 @@ use_bookmarks_method =
 # Possible values; error, roster, warning, info, help
 #information_buffer_popup_on = error roster warning help info
 
-# A list of message types that should be filtered out from the
+# A list of message types separated by colons (":") that should be filtered out from the
 # information buffer.
 # Possible values; error, roster, warning, info, help
 #information_buffer_type_filter =

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -634,7 +634,7 @@ or the way messages are displayed.
         Some informational messages (error, a contact getting connected, etc)
         are sometimes added to the information buffer.
 
-        A list of message types that should never be displayed in the information
+        A list of message types separated by colons (":") that should never be displayed in the information
         buffer.
         Possible values: ``error``, ``roster``, ``warning``, ``info``, ``help``
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -627,6 +627,17 @@ or the way messages are displayed.
         A list of message types that should make the information buffer grow
         Possible values: ``error``, ``roster``, ``warning``, ``info``, ``help``
 
+    information_popup_type_filter
+
+        **Default value:** ``[empty]``
+
+        Some informational messages (error, a contact getting connected, etc)
+        are sometimes added to the information buffer.
+
+        A list of message types that should never be displayed in the information
+        buffer.
+        Possible values: ``error``, ``roster``, ``warning``, ``info``, ``help``
+
     display_user_color_in_join_part
 
         **Default value:** ``true``

--- a/poezio/config.py
+++ b/poezio/config.py
@@ -74,6 +74,7 @@ DEFAULT_CONFIG = {
         'ignore_certificate': False,
         'ignore_private': False,
         'information_buffer_popup_on': 'error roster warning help info',
+        'information_buffer_type_filter': '',
         'jid': '',
         'keyfile': '',
         'lang': 'en',

--- a/poezio/core/core.py
+++ b/poezio/core/core.py
@@ -1405,10 +1405,14 @@ class Core(object):
         """
         Displays an informational message in the "Info" buffer
         """
+        filter_types = config.get('information_buffer_type_filter').split(':')
+        if typ.lower() in filter_types:
+            log.debug('Did not show the message:\n\t%s> %s \n\tdue to information_popup_type_filter configuration', typ, msg)
+            return False
         filter_messages = config.get('filter_info_messages').split(':')
         for words in filter_messages:
             if words and words in msg:
-                log.debug('Did not show the message:\n\t%s> %s', typ, msg)
+                log.debug('Did not show the message:\n\t%s> %s \n\tdue to filter_info_messages configuration', typ, msg)
                 return False
         colors = get_theme().INFO_COLORS
         color = colors.get(typ.lower(), colors.get('default', None))


### PR DESCRIPTION
filter an entire type of messages such as 'roster'
'error' 'information' or 'debug'