### PR TITLE
Add support for XEP-0392 (Consistent Color Generation)

### DIFF
--- a/poezio/colors.py
+++ b/poezio/colors.py
@@ -1,0 +1,102 @@
+import curses
+import hashlib
+import math
+
+# BT.601 (YCbCr) constants, see XEP-0392
+K_R = 0.299
+K_G = 0.587
+K_B = 1-K_R-K_G
+
+def ncurses_color_to_rgb(color):
+    if color <= 15:
+        try:
+            (r, g, b) = curses.color_content(color)
+        except:  # fallback in faulty terminals (e.g. xterm)
+            (r, g, b) = curses.color_content(color%8)
+        r = r / 1000 * 6 - 0.01
+        g = g / 1000 * 6 - 0.01
+        b = b / 1000 * 6 - 0.01
+    elif color <= 231:
+        color = color - 16
+        r = color % 6
+        color = color / 6
+        g = color % 6
+        color = color / 6
+        b = color % 6
+    else:
+        color -= 232
+        r = g = b = color / 24 * 6
+    return r / 6, g / 6, b / 6
+
+def rgb_to_ycbcr(r, g, b):
+    y = K_R * r + K_G * g + K_B * b
+    cr = (r - y) / (1 - K_R) / 2
+    cb = (b - y) / (1 - K_B) / 2
+    return y, cb, cr
+
+def generate_ccg_palette(curses_palette, reference_y):
+    cbcr_palette = {}
+    for curses_color in curses_palette:
+        r, g, b = ncurses_color_to_rgb(curses_color)
+        # drop grayscale
+        if r == g == b:
+            continue
+        y, cb, cr = rgb_to_ycbcr(r, g, b)
+        key = round(cbcr_to_angle(cb, cr), 2)
+        try:
+            existing_y, *_ = cbcr_palette[key]
+        except KeyError:
+            pass
+        else:
+            if abs(existing_y - reference_y) <= abs(y - reference_y):
+                continue
+        cbcr_palette[key] = y, curses_color
+    return {
+        angle: curses_color
+        for angle, (_, curses_color) in cbcr_palette.items()
+    }
+
+def text_to_angle(text):
+    hf = hashlib.sha1()
+    hf.update(text.encode("utf-8"))
+    hue = int.from_bytes(hf.digest()[:2], "little")
+    return hue / 65535 * math.pi * 2
+
+def angle_to_cbcr_edge(angle):
+    cr = math.sin(angle)
+    cb = math.cos(angle)
+    if abs(cr) > abs(cb):
+        factor = 0.5 / abs(cr)
+    else:
+        factor = 0.5 / abs(cb)
+    return cb*factor, cr*factor
+
+def cbcr_to_angle(cb, cr):
+    magn = math.sqrt(cb**2 + cr**2)
+    if magn > 0:
+        cr /= magn
+        cb /= magn
+    return math.atan2(cr, cb) % (2*math.pi)
+
+def ccg_palette_lookup(palette, angle):
+    # try quick lookup first
+    try:
+        color = palette[round(angle, 2)]
+    except KeyError:
+        pass
+    else:
+        return color
+
+    best_metric = float("inf")
+    best = None
+    for anglep, color in palette.items():
+        metric = abs(anglep - angle)
+        if metric < best_metric:
+            best_metric = metric
+            best = color
+
+    return best
+
+def ccg_text_to_color(palette, text):
+    angle = text_to_angle(text)
+    return ccg_palette_lookup(palette, angle)

--- a/poezio/colors.py
+++ b/poezio/colors.py
@@ -13,20 +13,20 @@ def ncurses_color_to_rgb(color):
             (r, g, b) = curses.color_content(color)
         except:  # fallback in faulty terminals (e.g. xterm)
             (r, g, b) = curses.color_content(color%8)
-        r = r / 1000 * 6 - 0.01
-        g = g / 1000 * 6 - 0.01
-        b = b / 1000 * 6 - 0.01
+        r = r / 1000 * 5
+        g = g / 1000 * 5
+        b = b / 1000 * 5
     elif color <= 231:
         color = color - 16
         r = color % 6
-        color = color / 6
+        color = color // 6
         g = color % 6
-        color = color / 6
+        color = color // 6
         b = color % 6
     else:
         color -= 232
-        r = g = b = color / 24 * 6
-    return r / 6, g / 6, b / 6
+        r = g = b = color / 24 * 5
+    return r / 5, g / 5, b / 5
 
 def rgb_to_ycbcr(r, g, b):
     y = K_R * r + K_G * g + K_B * b

--- a/poezio/theming.py
+++ b/poezio/theming.py
@@ -277,6 +277,10 @@ class Theme(object):
             (212, -1), (213, -1), (214, -1), (215, -1), (216, -1), (217, -1),
             (218, -1), (219, -1), (220, -1), (221, -1), (222, -1), (223, -1),
             (224, -1), (225, -1), (226, -1), (227, -1)]
+    # XEP-0392 consistent color generation palette placeholder
+    # it’s generated on first use when accessing the ccg_palette property
+    CCG_PALETTE = None
+    CCG_Y = 0.5**0.45
 
     # yapf: enable
 
@@ -517,17 +521,13 @@ def prepare_ccolor_palette(theme):
     """
     Prepare the Consistent Color Generation (XEP-0392) palette for a theme.
     """
-    if hasattr(theme, "CCG_PALETTE"):
-        # theme overrides the palette
+    if theme.CCG_PALETTE is not None:
         return
 
     if any(bg != -1 for fg, bg in theme.LIST_COLOR_NICKNAMES):
         # explicitly disable CCG, can’t handle dynamic background colors
-        theme.CCG_PALETTE = None
+        theme.CCG_PALETTE = {}
         return
-
-    if not hasattr(theme, "CCG_Y"):
-        theme.CCG_Y = 0.5**0.45
 
     theme.CCG_PALETTE = colors.generate_ccg_palette(
         [

--- a/poezio/xhtml.py
+++ b/poezio/xhtml.py
@@ -215,7 +215,7 @@ def get_body_from_message_stanza(message,
 
 def rgb_to_html(rgb):
     r, g, b = rgb
-    return '#%02X%02X%02X' % (int(r*256), int(g*256), int(b*256))
+    return '#%02X%02X%02X' % (round(r*255), round(g*255), round(b*255))
 
 def ncurses_color_to_html(color):
     """

--- a/poezio/xhtml.py
+++ b/poezio/xhtml.py
@@ -24,6 +24,7 @@ from xml.sax import saxutils
 
 from slixmpp.xmlstream import ET
 from poezio.config import config
+from poezio.colors import ncurses_color_to_rgb
 
 digits = '0123456789'  # never trust the modules
 
@@ -212,6 +213,9 @@ def get_body_from_message_stanza(message,
     content = content if content else message['body']
     return content or " "
 
+def rgb_to_html(rgb):
+    r, g, b = rgb
+    return '#%02X%02X%02X' % (int(r*256), int(g*256), int(b*256))
 
 def ncurses_color_to_html(color):
     """
@@ -219,27 +223,7 @@ def ncurses_color_to_html(color):
     a string of the form #XXXXXX representing an
     html color.
     """
-    if color <= 15:
-        try:
-            (r, g, b) = curses.color_content(color)
-        except:  # fallback in faulty terminals (e.g. xterm)
-            (r, g, b) = curses.color_content(color % 8)
-        r = r / 1000 * 6 - 0.01
-        g = g / 1000 * 6 - 0.01
-        b = b / 1000 * 6 - 0.01
-    elif color <= 231:
-        color = color - 16
-        r = color % 6
-        color = color / 6
-        g = color % 6
-        color = color / 6
-        b = color % 6
-    else:
-        color -= 232
-        r = g = b = color / 24 * 6
-    return '#%02X%02X%02X' % (int(r * 256 / 6), int(g * 256 / 6),
-                              int(b * 256 / 6))
-
+    return rgb_to_html(ncurses_color_to_rgb(color))
 
 def _parse_css_color(name):
     if name[0] == '#':


### PR DESCRIPTION
XEP-0392 specifies consistent generation of nickname (and other text) colors across clients.

This implementation is not conformant with the palette mapping specified in the current version of XEP-0392, but yields better results. I’ll update the XEP shortly.

Things which could be implemented but haven’t:

* Apply coloring for the own nickname
* Apply coloring in the roster somehow
* Apply coloring in 1-on-1 conversations.