### PR TITLE
Embed command

### DIFF
--- a/plugins/embed.py
+++ b/plugins/embed.py
@@ -1,0 +1,46 @@
+"""
+Display an image URL as an embedded image in some clients like Conversations.
+Uses: https://xmpp.org/extensions/xep-0066.html#x-oob
+
+Usage
+-----
+
+.. glossary::
+
+    /embed <image_url>
+
+        Run this command to send the <image_url> as an
+        embedded image in your contact's client.
+"""
+
+from poezio import tabs
+from poezio.decorators import command_args_parser
+from poezio.plugin import BasePlugin
+from poezio.theming import get_theme
+
+class Plugin(BasePlugin):
+
+    def init(self):
+        for tab_t in [tabs.MucTab, tabs.ConversationTab, tabs.PrivateTab]:
+            self.api.add_tab_command(tab_t, 'embed', self.embed_image_url,
+                                     help='Embed an image url into the contact\'s client',
+                                     usage='[image url]')
+
+    def embed_image_url(self, args):
+        tab = self.api.current_tab()
+        message = self.core.xmpp.make_message(tab.name)
+        message['body'] = args
+        message['oob']['url'] = args
+        if isinstance(tab, tabs.MucTab):
+            message['type'] = 'groupchat'
+        else:
+            message['type'] = 'chat'
+            tab.add_message(
+                message['body'],
+                nickname=tab.core.own_nick,
+                nick_color=get_theme().COLOR_OWN_NICK,
+                identifier=message['id'],
+                jid=tab.core.xmpp.boundjid,
+                typ=1,
+            )
+        message.send()

--- a/plugins/embed.py
+++ b/plugins/embed.py
@@ -14,7 +14,6 @@ Usage
 """
 
 from poezio import tabs
-from poezio.decorators import command_args_parser
 from poezio.plugin import BasePlugin
 from poezio.theming import get_theme
 

--- a/plugins/embed.py
+++ b/plugins/embed.py
@@ -24,7 +24,7 @@ class Plugin(BasePlugin):
         for tab_t in [tabs.MucTab, tabs.ConversationTab, tabs.PrivateTab]:
             self.api.add_tab_command(tab_t, 'embed', self.embed_image_url,
                                      help='Embed an image url into the contact\'s client',
-                                     usage='[image url]')
+                                     usage='<image_url>')
 
     def embed_image_url(self, args):
         tab = self.api.current_tab()


### PR DESCRIPTION
Hi!

I started this command to be able to display images in an embedded way in Conversations. I think more clients do the same thing, but this is the only one I have tested.

This is more for a review than anything else, it would be (maybe) nice to check if what the user is passing is a real URL ending with an image extension, and warn the user about it.

I'm also not catching any exception and I guess some may occur.

I don't know Poezio from de development side, so I may be doing terrible things, but as an start, the plugin is working pretty well.

As a future iteration of it, if URLs are checked, would be to parse the message's body and check if it's only a URL to an image, so you would not need to call the command like `/embed <image_url>`. Just send a link and that's all. And set a configuration option for this, being it automatic or manual.

Let me know! :smiley_cat: 